### PR TITLE
회원 로그인 구현 완료

### DIFF
--- a/backend/routes/users.js
+++ b/backend/routes/users.js
@@ -1,13 +1,36 @@
 const express = require("express");
 const router = express.Router();
 const User = require("../models/User");
-const bcrypt = require("bcrypt");
+const { createToken } = require("../utils/auth");
 
 router.post("/signup", async (req, res, next) => {
   try {
     const { id, password, nickname } = req.body;
     const user = await User.signUp(id, password, nickname);
     res.status(201).json(user);
+  } catch (err) {
+    console.error(err);
+    res.status(400).json({ message: err.message });
+    next(err);
+  }
+});
+
+router.post("/login", async (req, res, next) => {
+  try {
+    const { id, password } = req.body;
+    const user = await User.login(id, password);
+    const tokenMaxAge = 60 * 60 * 24 * 3;
+    const token = createToken(user, tokenMaxAge);
+
+    user.token = token;
+
+    res.cookie("authToken", token, {
+      httpOnly: true,
+      maxAge: tokenMaxAge * 1000,
+    });
+
+    console.log(user);
+    res.status(200).json(user);
   } catch (err) {
     console.error(err);
     res.status(400).json({ message: err.message });

--- a/backend/routes/users.js
+++ b/backend/routes/users.js
@@ -22,8 +22,6 @@ router.post("/login", async (req, res, next) => {
     const tokenMaxAge = 60 * 60 * 24 * 3;
     const token = createToken(user, tokenMaxAge);
 
-    user.token = token;
-
     res.cookie("authToken", token, {
       httpOnly: true,
       maxAge: tokenMaxAge * 1000,

--- a/backend/utils/auth.js
+++ b/backend/utils/auth.js
@@ -1,0 +1,17 @@
+const jwt = require("jsonwebtoken");
+
+function createToken(visibleUser, maxAge = 60 * 60 * 24 * 3) {
+  return jwt.sign(visibleUser, process.env.JWT_SECRET || "MyJWT", {
+    expiresIn: maxAge,
+  });
+}
+
+function verifyToken(token) {
+  if (!token) {
+    return null;
+  }
+  const verifiedToken = jwt.verify(token, process.env.JWT_SECRET || "MyJWT");
+  return verifiedToken;
+}
+
+module.exports = { createToken, verifyToken };


### PR DESCRIPTION
### PR 타입
- [✔] 기능 추가
- [] 기능 수정
- [] 기능 삭제
- [] 버그 수정
- [] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
hyeonju -> main

### 변경 사항
- 회원 로그인 기능을 구현했습니다.
- 회원에게 id, password를 입력받아 회원 여부를 확인하고, 회원이 맞다면 authToken을 발행합니다.
- authToken은 cookie로 전달합니다.(response header에서 확인 가능)

### 테스트 결과
1. 프로젝트를 실행한 후, `http://localhost:3000/users/login`에 POST 요청을 보냅니다. API 요청 시, request-body에는 다음과 같이 id와 password를 보냅니다.
```json
{
    "id": "dlguswn",
    "password": "eoskdfowne"
}
```
2. 200 status code를 확인하고, response-body와 response-header를 확인합니다.
- response-body에는 id와 nickname이 전달됩니다.(보완상의 이유로 password는 전달하지 않습니다.)
![image](https://github.com/PDI-foodi/Backend/assets/140503027/50417f56-1769-44a7-9584-97de214885fb)

- response-header의 "Set-Cookie"에 authToken이 전달됩니다.
![image](https://github.com/PDI-foodi/Backend/assets/140503027/c15b255e-0a01-4bb8-ac81-d681a91ebafd)

- response cookies에서도 authToken을 확인할 수 있습니다.
![image](https://github.com/PDI-foodi/Backend/assets/140503027/a9e76359-7dae-46d8-882e-f559e050048a)
