### PR TITLE
상세페이지 정보 조회 및 like테이블에 찜한 유저 , 맛집 아이디 저장 완료

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -39,15 +39,15 @@ app.use("/detail", detailRouter);
 app.use("/review", reviewRouter);
 
 //mongodb연결을위해 비밀번호 가림
-const dotenv=require('dotenv');
+const dotenv = require("dotenv");
 dotenv.config();
 
 //mongodb 연결
-const mongoose =require("mongoose");
-mongoose.connect(
-  process.env.MONGO_URI
-).then(()=>console.log("Connecting"))
-.catch(err=>console.log(err));
+const mongoose = require("mongoose");
+mongoose
+  .connect(process.env.MONGO_URI)
+  .then(() => console.log("Connecting"))
+  .catch((err) => console.log(err));
 
 // catch 404 and forward to error handler
 app.use(function (req, res, next) {

--- a/backend/models/Like.js
+++ b/backend/models/Like.js
@@ -2,9 +2,8 @@ const mongoose = require("mongoose");
 
 const likeSchema = new mongoose.Schema(
   {
-    id: { type: Number, required: true },
-    userId: { type: Number, required: true },
-    restaurantId: { type: Number, required: true },
+    userId: { type: String, required: true },
+    restaurantId: { type: String, required: true },
   },
   {
     timestamps: true,

--- a/backend/routes/detail.js
+++ b/backend/routes/detail.js
@@ -6,8 +6,15 @@ const LikeSchema = require("../models/Like");
 /* router.get("/:id", (req, res) => {
   console.log(req.data);
 }); */
+
 router.get("/", (req, res) => {
   Restaurant.find().then((result) => {
+    res.json(result);
+  });
+});
+
+router.get("/like", (req, res) => {
+  LikeSchema.find().then((result) => {
     res.json(result);
   });
 });

--- a/backend/routes/detail.js
+++ b/backend/routes/detail.js
@@ -1,5 +1,20 @@
-var express = require('express');
+var express = require("express");
 var router = express.Router();
+const Restaurant = require("../models/Restaurant");
 
+/* router.get("/:id", (req, res) => {
+  console.log(req.data);
+}); */
+router.get("/", (req, res) => {
+  Restaurant.find().then((result) => {
+    res.json(result);
+  });
+});
+
+router.get("/:id", (req, res) => {
+  Restaurant.findById(req.params.id).then((result) => {
+    res.json(result);
+  });
+});
 
 module.exports = router;

--- a/backend/routes/detail.js
+++ b/backend/routes/detail.js
@@ -1,6 +1,7 @@
 var express = require("express");
 var router = express.Router();
 const Restaurant = require("../models/Restaurant");
+const LikeSchema = require("../models/Like");
 
 /* router.get("/:id", (req, res) => {
   console.log(req.data);
@@ -14,6 +15,16 @@ router.get("/", (req, res) => {
 router.get("/:id", (req, res) => {
   Restaurant.findById(req.params.id).then((result) => {
     res.json(result);
+  });
+});
+
+router.post("/:id", (req, res) => {
+  const { userId } = req.body;
+  LikeSchema.create({
+    userId: userId,
+    restaurantId: req.params.id,
+  }).then((result) => {
+    res.status(200).json(result);
   });
 });
 


### PR DESCRIPTION
### PR 타입
- [✅] 기능 추가
- [] 기능 수정
- [] 기능 삭제
- [] 버그 수정
- [] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
* origin/jaein -> main

### 변경 사항
* router/detail부분을 작업했습니다
* Restaurant에서 특정 id를 가져와서 조회 완료했습니다
* 찜 버튼 누를시 userId 및 restaurantId를 저장한 정보를 like테이블에 추가했습니다.

### 테스트 결과
1) 상세페이지에서 해당 맛집 조회 결과입니다.
<img width="619" alt="image" src="https://github.com/PDI-foodi/Backend/assets/97165077/b087c7c9-46d6-4f50-99ac-e28168fa9166">

2)
찜 버튼 누를시 like테이블에 목록 추가,
like테이블 조회 결과입니다.
<img width="376" alt="image" src="https://github.com/PDI-foodi/Backend/assets/97165077/e732f00a-3294-4bd4-87db-9aef37986e37">

결과입니다!
