### PR TITLE
평점(rate)순으로 가게 정보 10개 가져오기 추가

### DIFF
--- a/backend/routes/ranking.js
+++ b/backend/routes/ranking.js
@@ -1,5 +1,18 @@
-var express = require('express');
+var express = require("express");
 var router = express.Router();
+const Restaurant = require("../models/Restaurant");
 
+router.get("/", (req, res) => {
+  Restaurant.find()
+    .select("imglink name rate category")
+    .sort({ rate: -1 })
+    .limit(10)
+    .then((result) => {
+      res.json(result);
+    })
+    .catch((err) => {
+      res.status(500).json({ error: err.message });
+    });
+});
 
 module.exports = router;


### PR DESCRIPTION
### PR 타입
- [✔] 기능 추가
- [] 기능 수정
- [] 기능 삭제
- [] 버그 수정
- [] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
● jinhyeok -> main

### 변경 사항
● 평점순으로 이미지링크, 가게이름, 평점, 카테고리를 10개 가져오는 로직 구현

### 테스트 결과
● http://localhost:3000/ranking에 GET요청을 보냅니다.
![image](https://github.com/PDI-foodi/Backend/assets/101380919/72e40617-b623-48b9-b7fa-cf0706a820b1)

● 평점순으로 정보를 가져오는 것을 확인합니다.
![image](https://github.com/PDI-foodi/Backend/assets/101380919/9353a22d-cc3d-4a66-81cc-f7e585e4799a)
![image](https://github.com/PDI-foodi/Backend/assets/101380919/f3a7a51f-4621-4470-ae6f-8d13b9eb5164)

