### PR TITLE
로그인, 회원가입 Error Handling 추가

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -65,7 +65,7 @@ app.use(function (err, req, res, next) {
 
   // render the error page
   res.status(err.status || 500);
-  res.render("error");
+  res.json(res.locals);
 });
 
 module.exports = app;

--- a/backend/routes/users.js
+++ b/backend/routes/users.js
@@ -9,9 +9,11 @@ router.post("/signup", async (req, res, next) => {
     const user = await User.signUp(id, password, nickname);
     res.status(201).json(user);
   } catch (err) {
-    console.error(err);
-    res.status(400).json({ message: err.message });
-    next(err);
+    if (err.name === 'IdDuplicatedError'){
+      return res.status(409).json({ message: err.message });
+    } else if (err.name === 'NicknameDuplicatedError'){
+      return res.status(409).json({ message: err.message });
+    }
   }
 });
 
@@ -30,9 +32,11 @@ router.post("/login", async (req, res, next) => {
     console.log(user);
     res.status(200).json(user);
   } catch (err) {
-    console.error(err);
-    res.status(400).json({ message: err.message });
-    next(err);
+    if (err.name === 'IdNotFoundError'){
+      return res.status(404).json({ message: err.message });
+    } else if (err.name === 'PasswordMismatchError'){
+      return res.status(401).json({ message: err.message });
+    }
   }
 });
 


### PR DESCRIPTION
### PR 타입
- [✔] 기능 추가
- [] 기능 수정
- [] 기능 삭제
- [] 버그 수정
- [] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
hyeonju -> main

### 변경 사항
- 로그인 시, 아이디 및 비밀번호 에러를 추가했습니다.
-> 아이디에 해당하는 유저가 없는 경우, "존재하지 않는 아이디입니다."
-> 아이디는 있지만 비밀번호가 틀린 경우, "비밀번호가 일치하지 않습니다."
- 회원가입 시, 아이디 및 닉네임 에러를 추가했습니다.
-> 이미 존재하는 아이디인 경우, "이미 존재하는 아이디입니다."
-> 이미 존재하는 닉네임인 경우, "이미 존재하는 닉네임입니다."

### 테스트 결과
1. Postman에서 `localhost:5000/users/signup`에 아래 body를 붙여 POST 요청을 보냅니다.
```json
{
    "id": "dlguswn",
    "password": "eoskdfowne",
    "nickname": "이현주"
}
```
2. 409 에러를 확인합니다.
<img src="https://github.com/PDI-foodi/Backend/assets/140503027/b4845893-33c8-430e-afb1-5ded63f98266" width=500 />

3. `localhost:5000/users/signup`에 아래 body를 붙여 POST 요청을 보냅니다.
```json
{
    "id": "dlguswn123",
    "password": "eoskdfowne",
    "nickname": "이현주"
}
```
4. 409 에러를 확인합니다.
<img src="https://github.com/PDI-foodi/Backend/assets/140503027/f543cb42-6a2b-44bd-92f1-6c518bca1f90" width=500 />

5. `localhost:5000/users/login`에 아래 body를 붙여 POST 요청을 보냅니다.
```json
{
    "id": "asdfqegrbddvadqetdf",
    "password": "eoskdfowne"
}
```
6. 404 에러를 확인합니다.
<img src="https://github.com/PDI-foodi/Backend/assets/140503027/2186000e-4e10-4775-817a-d27c38c8834c" width=500 />

7. `localhost:5000/users/login`에 아래 body를 붙여 POST 요청을 보냅니다.
```json
{
    "id": "dlguswn",
    "password": "eoskdfownesf"
}
```
8. 401 에러를 확인합니다.
<img src="https://github.com/PDI-foodi/Backend/assets/140503027/c0ac5215-ef40-4605-b85e-99243c00eeb9" width=500 />
