### PR TITLE
로그아웃 시, 쿠키에서 토큰 삭제

### DIFF
--- a/backend/routes/users.js
+++ b/backend/routes/users.js
@@ -40,6 +40,18 @@ router.post("/login", async (req, res, next) => {
   }
 });
 
+router.get("/logout", async (req, res, next) => {
+  try {
+    // res.cookie("authToken", "", {
+    //   httpOnly: true,
+    //   maxAge: 0,
+    // });
+    res.clearCookie("authToken").status(200).json({ message: "로그아웃 성공" });
+  } catch (err) {
+    return res.status(500).json({ message: err.message });
+  }
+});
+
 router.post("/find-pwd", async (req, res, next) => {
   try {
     const { id, nickname } = req.body;


### PR DESCRIPTION
### PR 타입
- [✔] 기능 추가
- [] 기능 수정
- [] 기능 삭제
- [] 버그 수정
- [] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
hyeonju -> main

### 변경 사항
- 로그아웃 요청 시, 회원의 쿠키에 있는 authToken을 삭제합니다.

### 테스트 결과
1. 프로젝트를 실행한 후, `localhost:5000/users/logout`에 GET 요청을 보냅니다.(아래처럼 쿠키에 authToken을 붙입니다.)
![image](https://github.com/PDI-foodi/Backend/assets/140503027/3bd2df96-b194-43fb-a580-dd5a7584e35b)

2. "로그아웃 성공" 메세지를 확인합니다.(200 status code를 확인합니다.)
![image](https://github.com/PDI-foodi/Backend/assets/140503027/ceb5ff14-ae4a-4152-96b6-b1c79ac1c672)

